### PR TITLE
Removing matplotlib as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 numpy
 scipy
-matplotlib
 opencv-python


### PR DESCRIPTION
It is not used in any of the compression code, and should not be a dependency, though it can be used to diagnosing issues.